### PR TITLE
fix exports missing createDigestClient method

### DIFF
--- a/http-digest-client.js
+++ b/http-digest-client.js
@@ -140,7 +140,9 @@ var HTTPDigest = function () {
   return HTTPDigest;
 }();
 
-module.exports = function createDigestClient(username, password, https) {
+module.exports = HTTPDigest;
+
+module.exports.createDigestClient = function createDigestClient(username, password, https) {
   return new HTTPDigest(username, password, https);
 };
 


### PR DESCRIPTION
seems to work now after getting errors

TypeError: Object function createDigestClient(username, password, https) {
  return new HTTPDigest(username, password, https);
} has no method 'createDigestClient'
